### PR TITLE
Adjust club serializer to allow clubs to be created without additiona…

### DIFF
--- a/app/clubs/serializers.py
+++ b/app/clubs/serializers.py
@@ -133,11 +133,12 @@ class ClubRoleSerializer(ModelSerializerBase):
 class ClubSerializer(ModelSerializerBase):
     """Represents a Club object with all fields."""
 
-    logo = ClubFileNestedSerializer()
+    id = serializers.IntegerField(required=False, min_value=1)
+    logo = ClubFileNestedSerializer(required=False)
     banner = ClubFileNestedSerializer(required=False, allow_null=True)
-    photos = ClubPhotoSerializer(many=True)
-    socials = ClubSocialSerializer(many=True)
-    tags = ClubTagSerializer(many=True)
+    photos = ClubPhotoSerializer(required=False, many=True)
+    socials = ClubSocialSerializer(required=False, many=True)
+    tags = ClubTagSerializer(required=False, many=True)
     majors = serializers.SlugRelatedField(
         slug_field="name",
         queryset=Major.objects.all(),
@@ -189,7 +190,10 @@ class ClubSerializer(ModelSerializerBase):
             club.logo_url = file
             club.save()
 
+        return club
+
     def update(self, instance, validated_data):
+        validated_data.pop("id", None)  # Ignore attempting to update an id
         logo_data = validated_data.pop("logo", None)
         banner_data = validated_data.pop("banner", None)
         socials_data = validated_data.pop("socials", [])

--- a/app/clubs/serializers.py
+++ b/app/clubs/serializers.py
@@ -133,7 +133,7 @@ class ClubRoleSerializer(ModelSerializerBase):
 class ClubSerializer(ModelSerializerBase):
     """Represents a Club object with all fields."""
 
-    id = serializers.IntegerField(required=False, min_value=1)
+    gatorconnect_organization_id = serializers.IntegerField(required=False, min_value=1)
     logo = ClubFileNestedSerializer(required=False)
     banner = ClubFileNestedSerializer(required=False, allow_null=True)
     photos = ClubPhotoSerializer(required=False, many=True)
@@ -178,6 +178,7 @@ class ClubSerializer(ModelSerializerBase):
             "roles",
             "instagram_followers",
             "logo_url",
+            "gatorconnect_organization_id",
             # "user_membership",
         ]
 
@@ -193,7 +194,6 @@ class ClubSerializer(ModelSerializerBase):
         return club
 
     def update(self, instance, validated_data):
-        validated_data.pop("id", None)  # Ignore attempting to update an id
         logo_data = validated_data.pop("logo", None)
         banner_data = validated_data.pop("banner", None)
         socials_data = validated_data.pop("socials", [])


### PR DESCRIPTION
…l required fields

### Description

Changes the following fields to not be required when uploading a new club: logo, photos, socials, tags. The purpose of this is to allow the ufclubs scraper to create new club objects without needing to populate info it does not have.

Also allows the id field to be passed to the create method (POST) only. This allows the scraper to create clubs and pass a specified id (gatorconnect id) rather than asking for a new id from the portal backend. Establishes a link between id on gatorconnect and club portal backend which I'm pretty sure we're already doing

Fixes # (issue)

---

### Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
