### PR TITLE
[CSU-542] Private events are only visible to members

### DIFF
--- a/app/events/models.py
+++ b/app/events/models.py
@@ -8,7 +8,7 @@ from zoneinfo import ZoneInfo
 
 from analytics.models import Link
 from clubs.models import Club, ClubFile, ClubScopedModel
-from core.abstracts.models import RoleType, ManagerBase, ModelBase, QuerySetBase, Tag
+from core.abstracts.models import ManagerBase, ModelBase, QuerySetBase, RoleType, Tag
 from django.core import exceptions
 from django.core.validators import MaxValueValidator
 from django.db import models

--- a/app/events/models.py
+++ b/app/events/models.py
@@ -8,7 +8,7 @@ from zoneinfo import ZoneInfo
 
 from analytics.models import Link
 from clubs.models import Club, ClubFile, ClubScopedModel
-from core.abstracts.models import ManagerBase, ModelBase, QuerySetBase, Tag
+from core.abstracts.models import RoleType, ManagerBase, ModelBase, QuerySetBase, Tag
 from django.core import exceptions
 from django.core.validators import MaxValueValidator
 from django.db import models

--- a/app/events/models.py
+++ b/app/events/models.py
@@ -309,7 +309,12 @@ class EventQuerySet(QuerySetBase["Event"]):
         elif user.is_anonymous:
             return self.none()
 
-        return self.filter(clubs__memberships__user=user)
+        return self.filter(clubs__memberships__user=user, clubs__memberships__roles__role_type__in=[
+                    RoleType.ADMIN,
+                    RoleType.EDITOR,
+                    RoleType.VIEWER,
+                    RoleType.CUSTOM,
+                ]).distinct()
 
     def get_for_user(self, id: int, user: User):
         """Get event for user, or throw 404."""

--- a/app/events/services.py
+++ b/app/events/services.py
@@ -516,7 +516,8 @@ class EventService(ServiceBase[Event]):
     @classmethod
     def get_event_heatmap(
         cls,
-        club_ids: list[int],
+        member_club_ids: Optional[list[int]] = None,
+        club_ids: Optional[list[int]] = None,
         start_date: Optional[datetime.date] = None,
         end_date: Optional[datetime.date] = None,
         include_public: Optional[bool] = False,
@@ -526,6 +527,9 @@ class EventService(ServiceBase[Event]):
         If start date is None, will default to current date.
         """
 
+        member_club_ids = member_club_ids or []
+        club_ids = club_ids or []
+
         tzname = timezone.get_current_timezone_name()
 
         if start_date is None:
@@ -533,6 +537,15 @@ class EventService(ServiceBase[Event]):
 
         if end_date is None:
             end_date = start_date + relativedelta(months=1) - datetime.timedelta(days=1)
+
+        def in_clause(ids: list[int]) -> str:
+            if not ids:
+                return "FALSE"
+            return f"club_id IN ({', '.join(['%s'] * len(ids))})"
+
+        member_filter = in_clause(member_club_ids)
+        public_clubs_filter = in_clause(club_ids)
+        include_public_sql = "TRUE" if include_public else "FALSE"
 
         query = f"""
             SELECT calendar::date AS day, COUNT(event.id) AS event_count, SUM(COUNT(event.id)) OVER (ORDER BY calendar::date) AS total_event_count
@@ -547,9 +560,11 @@ class EventService(ServiceBase[Event]):
                 LEFT JOIN public.events_eventhost AS host ON host.event_id = event.id
             ) AS event ON date_trunc('day', start_at AT TIME ZONE %s) = calendar
                 AND (
-                    club_id IN ({",".join(["%s" for _ in club_ids])})
-                    OR
-                    ({"is_public IS TRUE AND is_draft IS FALSE" if include_public else "FALSE"})
+                    ({member_filter})
+                    OR (
+                        is_public IS TRUE AND is_draft IS FALSE
+                        AND ({include_public_sql} OR ({public_clubs_filter}))
+                    )
                 )
             GROUP BY day
             ORDER BY day
@@ -562,6 +577,7 @@ class EventService(ServiceBase[Event]):
                     start_date.strftime("%m/%d/%Y"),
                     end_date.strftime("%m/%d/%Y"),
                     tzname,
+                    *member_club_ids,
                     *club_ids,
                 ],
             )

--- a/app/events/tests/test_event_service.py
+++ b/app/events/tests/test_event_service.py
@@ -65,7 +65,7 @@ class EventServiceTests(PeriodicTaskTestsBase):
         )
 
         # Get event count per day for club 1
-        h1 = EventService.get_event_heatmap(club_ids=[c1.id])
+        h1 = EventService.get_event_heatmap(member_club_ids=[c1.id])
 
         for date, count in h1.heatmap.items():
             if date.day == 15:
@@ -76,7 +76,7 @@ class EventServiceTests(PeriodicTaskTestsBase):
                 self.assertEqual(count, 0)
 
         # Get event count per day for club 2
-        h2 = EventService.get_event_heatmap(club_ids=[c2.id])
+        h2 = EventService.get_event_heatmap(member_club_ids=[c2.id])
 
         for _, count in h2.heatmap.items():
             self.assertEqual(count, 0)
@@ -94,7 +94,7 @@ class EventServiceTests(PeriodicTaskTestsBase):
             end_at=datetime.datetime(2025, 12, 18, 3, 0, tzinfo=datetime.UTC),
         )
 
-        heatmap = EventService.get_event_heatmap(club_ids=[c1.id])
+        heatmap = EventService.get_event_heatmap(member_club_ids=[c1.id])
 
         self.assertEqual(heatmap.heatmap[datetime.date(2025, 12, 17)], 1)
         self.assertEqual(heatmap.heatmap[datetime.date(2025, 12, 18)], 0)

--- a/app/events/viewsets.py
+++ b/app/events/viewsets.py
@@ -438,12 +438,30 @@ class EventHeatmapViewSet(APIView):
         end_date: Optional[date] = None,
         include_public: Optional[bool] = False,
     ):
-        # Parse club ids
-        if clubs is None:
-            clubs = list(
-                Club.objects.filter_for_user(request.user).values_list("id", flat=True)
+        member_club_ids = list(
+            Club.objects.filter(
+                memberships__user=request.user,
+                memberships__roles__role_type__in=[
+                    RoleType.ADMIN,
+                    RoleType.EDITOR,
+                    RoleType.VIEWER,
+                    RoleType.CUSTOM,
+                ],
             )
+            .values_list("id", flat=True)
+            .distinct()
+        )
 
+        if clubs is not None:
+            member_club_ids = [c for c in clubs if c in set(member_club_ids)]
+            requested_club_ids = clubs
+        else:
+            requested_club_ids = list(
+                Club.objects.filter(memberships__user=request.user)
+                .values_list("id", flat=True)
+                .distinct()
+            )
+        
         # Get start/end dates
         now = datetime.now()
         if start_date is None:
@@ -465,7 +483,8 @@ class EventHeatmapViewSet(APIView):
 
         # Generate heatmap
         heatmap = EventService.get_event_heatmap(
-            club_ids=clubs,
+            member_club_ids=member_club_ids,
+            club_ids=requested_club_ids,
             start_date=start_date,
             end_date=end_date,
             include_public=include_public,

--- a/app/events/viewsets.py
+++ b/app/events/viewsets.py
@@ -2,6 +2,7 @@ from datetime import date, datetime, timedelta
 from typing import Optional
 
 from clubs.models import Club, ClubFile
+from core.abstracts.models import RoleType
 from core.abstracts.viewsets import (
     ModelPreviewViewSetBase,
     ModelViewSetBase,
@@ -255,7 +256,13 @@ class EventViewset(ModelViewSetBase):
         if include_public:
             # Include events from user's clubs OR public non-draft events from any club
             queryset = queryset.filter(
-                Q(clubs__memberships__user=self.request.user)
+                Q(clubs__memberships__user=self.request.user,
+                clubs__memberships__roles__role_type__in=[
+                    RoleType.ADMIN,
+                    RoleType.EDITOR,
+                    RoleType.VIEWER,
+                    RoleType.CUSTOM,
+                ])
                 | (Q(is_public=True) & Q(is_draft=False))
             ).distinct()
         else:

--- a/app/events/viewsets.py
+++ b/app/events/viewsets.py
@@ -461,7 +461,7 @@ class EventHeatmapViewSet(APIView):
                 .values_list("id", flat=True)
                 .distinct()
             )
-        
+
         # Get start/end dates
         now = datetime.now()
         if start_date is None:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "club-portal-backend",
+  "name": "backend",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {


### PR DESCRIPTION
### Description

Member-only events were visible to followers. Fixed backend request to filter by user status. Also fixed event heatmap that suffered from same issue. 

Related PR also on frontend.

Fixes #542
---

### Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
